### PR TITLE
Fixed UIImage+Gif.swift and RootViewController.swift

### DIFF
--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -18,13 +18,12 @@ extension UIImage {
         return image
     }
     
-    class func delayForImageAtIndex(index: UInt, source: CGImageSourceRef)
+    class func delayForImageAtIndex(index: Int, source: CGImageSource!)
         -> Double {
         var delay = 0.1
         
         // Get dictionaries
-        let cfProperties = CGImageSourceCopyPropertiesAtIndex(source, index,
-            nil)
+        let cfProperties = CGImageSourceCopyPropertiesAtIndex(source,index,nil)
         let gifProperties: CFDictionaryRef = unsafeBitCast(
             CFDictionaryGetValue(cfProperties,
                 unsafeAddressOf(kCGImagePropertyGIFDictionary)),
@@ -108,7 +107,7 @@ extension UIImage {
             images.append(CGImageSourceCreateImageAtIndex(source, i, nil))
             
             // At it's delay in cs
-            var delaySeconds = UIImage.delayForImageAtIndex(UInt(i),
+            var delaySeconds = UIImage.delayForImageAtIndex(Int(i),
                 source: source)
             delays.append(Int(delaySeconds * 1000.0)) // Seconds to ms
         }

--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -23,7 +23,7 @@ extension UIImage {
         var delay = 0.1
         
         // Get dictionaries
-        let cfProperties = CGImageSourceCopyPropertiesAtIndex(source,index,nil)
+        let cfProperties = CGImageSourceCopyPropertiesAtIndex(source, index, nil)
         let gifProperties: CFDictionaryRef = unsafeBitCast(
             CFDictionaryGetValue(cfProperties,
                 unsafeAddressOf(kCGImagePropertyGIFDictionary)),

--- a/SwiftGifDemo/RootViewController.swift
+++ b/SwiftGifDemo/RootViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RootViewController: UIViewController {
     
-    override init() {
+    init() {
         super.init(nibName: nil, bundle: nil);
     }
 


### PR DESCRIPTION
I fixed the bug as referenced in Issue Compile Fail with Xcode 6.3
Final #3.  I also removed the word override in the init() function of
RootViewController because it was causing a compiler error.  I tested
and it compiles and runs the SwiftGif.xcodeproj.