### PR TITLE
added CocoaPods podspec

### DIFF
--- a/SwiftGif.podspec
+++ b/SwiftGif.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = 'SwiftGif'
+  s.version      = '1.3.1'
+  s.summary      = 'A small UIImage extension with gif support'
+  s.homepage     = 'https://github.com/bahlo/SwiftGif'
+  s.license      = 'MIT'
+  s.author       = { 'Arne Bahlo': 'hallo@arne.me' }
+
+  s.ios.deployment_target = '8.0'
+
+  s.source = {
+    git: 'https://github.com/bahlo/SwiftGif.git',
+    tag: 'v1.3.1'
+  }
+
+  s.source_files = 'SwiftGifCommon/*.swift'
+end

--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -11,7 +11,7 @@ import ImageIO
 
 extension UIImage {
     
-    class func animatedImageWithData(data: NSData) -> UIImage? {
+    public class func animatedImageWithData(data: NSData) -> UIImage? {
         let source = CGImageSourceCreateWithData(data, nil)
         let image = UIImage.animatedImageWithSource(source)
         
@@ -96,7 +96,7 @@ extension UIImage {
         return gcd
     }
     
-    class func animatedImageWithSource(source: CGImageSource) -> UIImage? {
+    public class func animatedImageWithSource(source: CGImageSource) -> UIImage? {
         let count = CGImageSourceGetCount(source)
         var images = [CGImageRef]()
         var delays = [Int]()


### PR DESCRIPTION
This implements #5. I couldn't easily test it in my app (it seems Swift pods cause a lot of problems and you need to change a lot of things, and they're only available on iOS 8...), but I've tested it in a fresh app that had nothing else in it, and it looks like it works.

I also had to change the access level of some methods to "public" to make them available to code outside the SwiftGif module.

To release a new version to CocoaPods, you need to add a new tag to the repo, update the version and tag name in the podfile, and then upload it to the CocoaPods repo (https://guides.cocoapods.org/making/getting-setup-with-trunk.html).
