### PR TITLE
fixes for Xcode 7 & Swift 2

### DIFF
--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -12,10 +12,9 @@ import ImageIO
 extension UIImage {
     
     class func animatedImageWithData(data: NSData) -> UIImage? {
-        let source = CGImageSourceCreateWithData(data, nil)
-        let image = UIImage.animatedImageWithSource(source)
-        
-        return image
+        guard let source = CGImageSourceCreateWithData(data, nil) else { return nil }
+
+        return UIImage.animatedImageWithSource(source)
     }
     
     class func delayForImageAtIndex(index: Int, source: CGImageSource!)
@@ -63,7 +62,7 @@ extension UIImage {
         
         // Swap for modulo
         if a < b {
-            var c = a
+            let c = a
             a = b
             b = c
         }
@@ -104,10 +103,12 @@ extension UIImage {
         // Fill arrays
         for i in 0..<count {
             // Add image
-            images.append(CGImageSourceCreateImageAtIndex(source, i, nil))
+            if let image = CGImageSourceCreateImageAtIndex(source, i, nil) {
+                images.append(image)
+            }
             
             // At it's delay in cs
-            var delaySeconds = UIImage.delayForImageAtIndex(Int(i),
+            let delaySeconds = UIImage.delayForImageAtIndex(Int(i),
                 source: source)
             delays.append(Int(delaySeconds * 1000.0)) // Seconds to ms
         }
@@ -130,10 +131,10 @@ extension UIImage {
         var frame: UIImage
         var frameCount: Int
         for i in 0..<count {
-            frame = UIImage(CGImage: images[Int(i)])!
+            frame = UIImage(CGImage: images[Int(i)])
             frameCount = Int(delays[Int(i)] / gcd)
             
-            for j in 0..<frameCount {
+            for _ in 0..<frameCount {
                 frames.append(frame)
             }
         }


### PR DESCRIPTION
- `CGImageSourceCreateWithData` and `CGImageSourceCreateImageAtIndex ` now return an optional
- `UIImage(CGImage:)` now returns a non-optional
- Xcode now shows warnings about unused variables and `var` variables that are never changed
