### PR TITLE
Load gif from asset catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ let jeremyGif = UIImage.gif(name: "jeremy")
 // A UIImageView with async loading
 let imageView = UIImageView()
 imageView.loadGif(name: "jeremy")
+
+// A UIImageView with async loading from asset catalog(from iOS9)
+let imageView = UIImageView()
+imageView.loadGif(asset: "jeremy")
 ```
 
 ## Installation

--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -20,6 +20,16 @@ extension UIImageView {
         }
     }
 
+    @available(iOS 9.0, *)
+    public func loadGif(asset: String) {
+        DispatchQueue.global().async {
+            let image = UIImage.gif(asset: asset)
+            DispatchQueue.main.async {
+                self.image = image
+            }
+        }
+    }
+
 }
 
 extension UIImage {
@@ -65,6 +75,17 @@ extension UIImage {
         }
 
         return gif(data: imageData)
+    }
+
+    @available(iOS 9.0, *)
+    public class func gif(asset: String) -> UIImage? {
+        // Create source from assets catalog
+        guard let dataAsset = NSDataAsset(name: asset) else {
+            print("SwiftGif: Cannot turn image named \"\(asset)\" into NSDataAsset")
+            return nil
+        }
+
+        return gif(data: dataAsset.data)
     }
 
     internal class func delayForImageAtIndex(_ index: Int, source: CGImageSource!) -> Double {


### PR DESCRIPTION
related. https://github.com/bahlo/SwiftGif/issues/66

Usually we're put image resources on assets catalog. 
So if SwiftGif can load gif from there, it's more useful.

Can you check This PR? @bahlo 

If you  accept this PR, I'd like to use this feature on new library version :)